### PR TITLE
added gsub for to convert '?' strands to '*'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: snapcount
 Type: Package
 Title: R/Bioconductor Package for interfacing with Snaptron for rapid querying of expression counts
-Version: 0.99.17
+Version: 0.99.18
 Author: Rone Charles
 Maintainer: Rone Charles <rcharle8@jh.edu>
 Description: snapcount is a client interface to the Snaptron webservices

--- a/R/basic_query_functions.R
+++ b/R/basic_query_functions.R
@@ -387,7 +387,7 @@ get_row_ranges <- function(query_data) {
     GRanges(
         seqnames = query_data$chromosome,
         IRanges::IRanges(query_data$start, query_data$end),
-        strand = query_data$strand,
+        strand = gsub("\\?", "*", query_data$strand),
         mcols
     )
 }


### PR DESCRIPTION
Hello, 

Thanks for putting together snapcount: it makes our jobs easier to many :)

I noticed that in the most recent versions of the database, sometimes the junction's strands are reported as "?". This caused errors when converting these junctions to a **GRanges** objects (and subsequently, **SummarizedExperiments** objects. 

I added a `gsub` to convert '?' strands to "*" before converting to GRanges objects.

Hope this is useful,
Alejandro